### PR TITLE
fix(proxy): forward response_format to upstream Qwen API

### DIFF
--- a/src/qwen/api.ts
+++ b/src/qwen/api.ts
@@ -806,6 +806,7 @@ export class QwenAPI {
       tool_choice: request.tool_choice,
       ...resolveThinkingParams(request),
       stream: false,
+      response_format: request.response_format,
     };
 
     try {
@@ -853,6 +854,7 @@ export class QwenAPI {
       ...resolveThinkingParams(request),
       stream: true,
       stream_options: { include_usage: true },
+      response_format: request.response_format,
     };
 
     try {

--- a/src/server/proxy-controller.ts
+++ b/src/server/proxy-controller.ts
@@ -192,6 +192,7 @@ export class QwenOpenAIProxy {
         reasoning: req.body.reasoning,
         enable_thinking: req.body.enable_thinking,
         thinking_budget: req.body.thinking_budget,
+        response_format: req.body.response_format,
         accountId,
       });
 
@@ -247,6 +248,7 @@ export class QwenOpenAIProxy {
         reasoning: req.body.reasoning,
         enable_thinking: req.body.enable_thinking,
         thinking_budget: req.body.thinking_budget,
+        response_format: req.body.response_format,
         accountId,
       });
 


### PR DESCRIPTION
## fix(proxy): forward response_format to upstream Qwen API

### Problem
The proxy silently dropped `response_format` from incoming chat completion requests. Clients requesting structured JSON (e.g., `response_format: {type: "json_object"}`) received markdown-fenced prose instead of raw JSON, causing downstream JSON parsing failures.

### Solution
Forward `response_format` verbatim through both proxy layers:

- **proxy-controller.ts**: Added `response_format` to `chatCompletions()` and `streamChatCompletions()` calls
- **api.ts**: Added `response_format` to both `processRequestWithAccount` and `processStreamingRequestWithAccount` payload builders

### Changes
- `src/server/proxy-controller.ts` — 2 lines added (non-streaming + streaming paths)
- `src/qwen/api.ts` — 2 lines added (regular + streaming request payloads)

### Verification
```bash
curl -s -X POST http://localhost:3009/v1/chat/completions \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <key>" \
  -d '{"model":"coder-model","messages":[{"role":"user","content":"test"}],"response_format":{"type":"json_object"}}'
# Returns raw JSON — no markdown fences
```

### Impact
- Zero breaking changes — `response_format` is forwarded only when present in the request
- No changes to auth, logging, error handling, or other request fields
- Both streaming and non-streaming paths patched